### PR TITLE
remove restart command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -385,10 +385,6 @@ void getCommandSchemaJson(JsonVariant json)
   }
   required.add("strip");
 
-  JsonObject restart = properties.createNestedObject("restart");
-  restart["type"] = "boolean";
-  restart["description"] = "Restart the controller";
-
   // Add any sensor commands
   sensors.setCommandSchema(properties);
 }
@@ -733,11 +729,6 @@ void jsonCommand(JsonVariant json)
     {
       jsonChannelCommand(channel);
     }
-  }
-
-  if (json.containsKey("restart") && json["restart"].as<bool>())
-  {
-    ESP.restart();
   }
 
   // Let the sensors handle any commands


### PR DESCRIPTION
The restart command is redundant now we have the `api/restart` REST API endpoint. I have removed this from the Rack32 library.